### PR TITLE
Drop support for old rubies.  Fixes #6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
-  - jruby-18mode
+  - 2.0.0
+  - jruby-19mode
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in test.gemspec
 gemspec
 
-
-gem 'rcov', :platform => :mri_18
-gem 'simplecov', :platform => :mri_19
-gem 'simplecov-rcov', :platform => :mri_19
+gem 'simplecov'
+gem 'simplecov-rcov'

--- a/lib/noid/minter.rb
+++ b/lib/noid/minter.rb
@@ -1,5 +1,3 @@
-require 'backports' if RUBY_VERSION.to_f < 1.9
-
 module Noid
   class Minter
     attr_reader :seed, :seq

--- a/noid.gemspec
+++ b/noid.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "backports"
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 2.0"

--- a/noid.gemspec
+++ b/noid.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 2.0"

--- a/noid.gemspec
+++ b/noid.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |s|
   s.email       = ["chris@cbeer.info"]
   s.homepage    = "http://github.com/microservices/noid"
   s.summary     = %q{Nice Opaque Identifier}
-  s.description = %q{}
+  s.description = %q{Nice Opaque Identifier}
+  s.licenses    = ["MIT"]
 
   s.rubyforge_project = "noid"
 


### PR DESCRIPTION
This fixes #6.

I include @jcoyne's changes from #7.  Since dropping backports implies dropping support for Ruby 1.8, I've updated the Gemfile, gemspec, and .travis.yml accordingly.
